### PR TITLE
Add cronjob to collect dumps

### DIFF
--- a/cronjobs/root_cronjobs.txt
+++ b/cronjobs/root_cronjobs.txt
@@ -1,0 +1,7 @@
+# Clear out unneeded daily .bz2 database backups in /backups/
+55 05 * * * /backups/purge.sh /backups >/var/log/tfc_prod/backup_purge.log 2>&1 && echo $(date --iso-8601=seconds) > /var/log/tfc_prod/backup_purge.timestamp
+
+# Disable cloudamber_data_monitor_json_fast monit task overnight
+# (when there are so few busses that it otherwise generates false positives)
+00 07 * * * /usr/bin/monit monitor cloudamber_data_monitor_json_fast
+00 22 * * * /usr/bin/monit unmonitor cloudamber_data_monitor_json_fast

--- a/cronjobs/tfc_web_cronjobs.txt
+++ b/cronjobs/tfc_web_cronjobs.txt
@@ -9,3 +9,7 @@ MAILTO=admin@smartcambridge.org
 
 # Clean out expired sessions. This task will be executed every Tuesday at 2 AM
 0 2 * * tue cd /home/tfc_prod/tfc_web/tfc_web/ && /home/tfc_prod/tfc_web_venv/bin/python /home/tfc_prod/tfc_web/tfc_web/manage.py clearsessions --settings="tfc_web.settings_production"
+
+# rsync smartcambridge.org/backups to /mnt/sdd1/smartcambridge.org/backups
+# tfc-app1: 23 mins, tfc-app2: 05 mins, tfc-app3: 33 mins, tfc-app4: 13 mins
+13 05 * * * /mnt/sdd1/smartcambridge.org/backups/rsync.sh /mnt/sdd1/smartcambridge.org/backups/


### PR DESCRIPTION
Add a tfc_prod cronjob to collect database backups from whichever
machine is running smartcambridge.org and store them in
/mnt/sdd1/smartcambridge.org/backups.

The time this job runs should be different on each machine.