### PR TITLE
Add www.smartcambridge.org and IP address, push keys onto one line

### DIFF
--- a/scripts/update_known_hosts.sh
+++ b/scripts/update_known_hosts.sh
@@ -18,6 +18,7 @@ for n in 1 2 3 4 5;
 do
   name=tfc-app${n}.cl.cam.ac.uk
   entry=$(ssh-keyscan -t ecdsa $name)
+  ip=$(dig +short $name)
   #ssh-keyscan -t ecdsa $name
   entrylength=${#entry}
   if ((entrylength <= 20))
@@ -25,7 +26,6 @@ do
       echo bad exit for $name 1>&2
       continue
   fi
-  echo $entry
-  echo ${entry/$name/smartcambridge.org}
+  echo ${entry/$name/$name,smartcambridge.org,www.smartcambridge.org,$ip}
 done
 


### PR DESCRIPTION
The LetsEncrypt automation needs to be able to ssh as
'www.smartcambridge.org' as well as 'smartcambrifgr.org', so add that to
the generated ssh_known_hosts file.

ssh checks IP address and well as hostname against authorized_keys by
default. While it's not a fault if its missing, it adds it to
~/.ssh/authorized_keys and this will be a pain if our
hostname-to-IP-address mapping changes in the future. So add each
server's IP address to the file too.

At the same time simplify the file by listing all the hostnames and the
IP address against a single copy of each key.