### PR TITLE
Jw35 pocketlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,11 @@ ln -s /mnt/sdb1/tfc/cam_park_rss /media/tfc/cam_park_rss
 # copy data into tfc/sys
 
 cp -r /home/tfc_prod/tfc_prod/config/sys/* /media/tfc/sys
+
+# Create tfc_web log directories
+
+mkdir /var/log/tfc_prod/gunicorn
+mkdir /var/log/tfc_prod/pocket_log
 ```
 
 ### Test run Rita Console
@@ -350,6 +355,13 @@ Test by browsing to ```http://localhost:8081/console``` and ```http://localhost/
 ```
 git clone https://github.com/ijl20/tfc_web.git
 ```
+
+### Setup log rotation
+
+```
+sudo cp logrotate/tfc_prod /etc/logrotate.d/tfc_prod
+```
+
 ### See tfc_web/README.md
 
 ### Configure email (for Monit alerts)

--- a/logrotate/tfc_prod
+++ b/logrotate/tfc_prod
@@ -1,0 +1,36 @@
+# tfc_prod log rotation configuration
+
+# Rotate tfc_web's gunicorn.err file and extract useful info
+
+/var/log/tfc_prod/gunicorn.err {
+    daily
+    missingok
+    nodateext
+    rotate 12
+    olddir gunicorn
+    compress
+    delaycompress
+    create 0644 tfc_prod tfc_prod
+    postrotate
+        kill -USR1 $(cat /var/log/tfc_prod/gunicorn.pid) > /dev/null 2>/dev/null || true
+        mkdir -p /var/log/tfc_prod/pocket_log
+        grep '|logger|pocket|' /var/log/tfc_prod/gunicorn/gunicorn.err.1 >> /var/log/tfc_prod/pocket_log/pocket_log.$(date +%F).log
+	(for f in /var/log/tfc_prod/pocket_log/pocket_log.*.log; do cat ${f}; done) | /home/tfc_prod/tfc_prod/tools/sumarise_pocket_log.py > /var/log/tfc_prod/pocket_log/pocket_log.csv
+    endscript
+}
+
+# Rotate tfc_web's gunicorn.log file
+
+/var/log/tfc_prod/gunicorn.log {
+    daily
+    missingok
+    nodateext
+    rotate 12
+    olddir gunicorn
+    compress
+    delaycompress
+    create 0644 tfc_prod tfc_prod
+    postrotate
+        kill -USR1 $(cat /var/log/tfc_prod/gunicorn.pid) > /dev/null 2>/dev/null || true
+    endscript
+}

--- a/nginx/includes2/tfc_web.conf
+++ b/nginx/includes2/tfc_web.conf
@@ -1,6 +1,20 @@
 ######################################################################
 ###################### /tfc_web  ##################################
 ######################################################################
+
+# The analysed Pocket Smartpanel logfile, for /smartpanel/pocketlog/
+
+    location /smartpanel/pocketlog/pocketlog.csv {
+        # Redirect to https
+        if ($do_redirect = YY) {
+          return 301 https://$host$request_uri;
+        }
+        types {
+            text/csv csv;
+        }
+        alias /var/log/tfc_prod/pocket_log/pocket_log.csv;
+    }
+
     location / {
 
         # Redirect to https

--- a/tools/mkdirs_tfc_prod.sh
+++ b/tools/mkdirs_tfc_prod.sh
@@ -47,3 +47,8 @@ ln -sfn /mnt/sdb1/tfc/cam_aq /media/tfc/cam_aq
 # copy data into tfc/sys
 
 cp -r /home/tfc_prod/tfc_prod/config/sys/* /media/tfc/sys
+
+# Create tfc_web log directories
+
+mkdir /var/log/tfc_prod/gunicorn
+mkdir /var/log/tfc_prod/pocket_log

--- a/tools/sumarise_pocket_log.py
+++ b/tools/sumarise_pocket_log.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+from collections import defaultdict
+from datetime import timedelta, datetime
+
+import csv
+import fileinput
+import pytz
+import sys
+
+uk_timezone = pytz.timezone('Europe/London')
+iso_format = '%Y-%m-%d %H:%M:%S'
+
+
+def truncate_to_bin(date):
+    '''
+    Round date down to bin start date
+    '''
+
+    return date - timedelta(days=date.weekday())
+
+
+def read_data():
+
+    results = []
+    current_bin = None
+    active = 0
+    inactive = 0
+    last_seen = {}
+
+    for line in fileinput.input():
+
+        timestamp = uk_timezone.localize(datetime.strptime(line[1:20], iso_format))
+        date = timestamp.date()
+        client = line.split('|')[3]
+
+        bin = truncate_to_bin(date)
+
+        # If we've crossed a bin boundary
+        if current_bin != bin:
+            if current_bin:
+                results.append([current_bin, active, inactive])
+            seen = set()
+            current_bin = bin
+            active = 0
+            inactive = 0
+
+        # Process first hit for each client in each bin
+        if client not in seen:
+            seen.add(client)
+
+            if client in last_seen and last_seen[client] >= date - timedelta(days=30):
+                active += 1
+            else:
+                inactive += 1
+
+        # Record seeing this client on this day
+        last_seen[client] = date
+
+    # Explicitly ignore the 'in-process' bin at the end of the file
+    # because it (almost certainly) contains data for a partial period
+
+    return results
+
+
+def save_data():
+    writer = csv.writer(sys.stdout)
+    writer.writerow(['Date', 'Active', 'Inactive'])
+    writer.writerows(read_data())
+
+
+def run():
+    save_data()
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
1) Setup gunicorn log rotation
    
    Arrange to rotate the gunicorn .log and .err files, keeping recent
    files in /var/log/tc_prod/gunicorn/
   
2) Extract Pocket Smartpanel usage logs
    
    As part of the rotation, extract lines from the Pocket Smartpanel
    usage logger into files in /var/log/tfc_prod/pocket_log/ and summarise
    them into /var/log/tfc_prod/pocket_log/pocket_log.csv

3) Arrange to serve the extracted Pocket Smartpanel log file
    
    At /smartpanel/pocketlog/pocketlog.csv