### PR TITLE
Add nginx config for downoad API files

### DIFF
--- a/nginx/includes2/tfc_web.conf
+++ b/nginx/includes2/tfc_web.conf
@@ -15,6 +15,32 @@
         alias /var/log/tfc_prod/pocket_log/pocket_log.csv;
     }
 
+# Serve the archived files for the download API that are stored in
+# /media/tfc/download_api/ from URLs http[s]://...../api/download_files.
+
+# These are protected using Django authentication via Nginx's auth_request
+# module. This uses a call to /api/nginx-auth-probe/ (implimented
+# in tfc_web/api/views.ps) to check the user is authenicated, If not,
+# the error_page entry redirects them to /api/login-and-agree
+# (also in tfc_web/api/views.ps) which will prompt them to login
+# and/or agree to the TaCs before sending them backto the URL they
+# wanted in the first place. The '@' in '@error403' makes this a 'named
+# location' which isn't used for regular request processing.
+
+    location /api/download_files {
+        # Redirect to https
+        if ($do_redirect = YY) {
+          return 301 https://$host$request_uri;
+        }
+        alias /media/tfc/download_api/;
+	auth_request /api/nginx-auth-probe/;
+        error_page 403 = @error403;
+	autoindex on;
+    }
+    location @error403 {
+        return 302 https://$http_host/api/login-and-agree/?next=https://$http_host$request_uri;
+    }
+
     location / {
 
         # Redirect to https


### PR DESCRIPTION
Add config to serve compressed archive files for the download API
from /media/tfc/download_api under URLs starting
http[s]://...../api/download_files

Access to these files requires that the user is authenticated to
Django and has accepted the SmartCambridge T&Cs. This is enforced
using Nginx's auth_request module which makes a call to a probe
endpoint (implemented in tfc_web as part of commit b9fef6c3).
Users that fail the test are redirected to the existing
/api/login-and-agree endpoint to complete the authentication
process, after which they are returned to the URL they originally
requested.

The archived files are served direct by Nginx to avoid the
overhead of going through Python ad Django for what could be
substantial files.