### PR TITLE
Add cronjob and monit monitor for downlad API data

### DIFF
--- a/cronjobs/tfc_web_cronjobs.txt
+++ b/cronjobs/tfc_web_cronjobs.txt
@@ -7,6 +7,9 @@ MAILTO=admin@smartcambridge.org
 # Bus Schedules. This task will be executed every Wednesday at 3 AM
 0 3 * * wed cd /home/tfc_prod/tfc_web/tfc_web/ && /home/tfc_prod/tfc_web_venv/bin/python /home/tfc_prod/tfc_web/tfc_web/manage.py update_bus_info --settings="tfc_web.settings_production" >/var/log/tfc_prod/update_bus_info.err 2>&1 && echo $(date --iso-8601=seconds) > /var/log/tfc_prod/update_bus_info.timestamp
 
+# Download data. This task will be executed every day at 4:28 AM
+28 4 * * * cd /home/tfc_prod/tfc_web/tfc_web/ && /home/tfc_prod/tfc_web_venv/bin/python /home/tfc_prod/tfc_web/tfc_web/manage.py build_download_data --settings="tfc_web.settings_production" >/var/log/tfc_prod/build_download_data.err 2>&1 && echo $(date --iso-8601=seconds) > /var/log/tfc_prod/build_download_data.timestamp
+
 # Clean out expired sessions. This task will be executed every Tuesday at 2 AM
 0 2 * * tue cd /home/tfc_prod/tfc_web/tfc_web/ && /home/tfc_prod/tfc_web_venv/bin/python /home/tfc_prod/tfc_web/tfc_web/manage.py clearsessions --settings="tfc_web.settings_production"
 

--- a/monit/conf-available/tfc_web_cronjobs
+++ b/monit/conf-available/tfc_web_cronjobs
@@ -7,3 +7,7 @@ check file update_bus_stops with path /var/log/tfc_prod/update_bus_stops.timesta
 # Time table info updated every week
 check file update_bus_info with path /var/log/tfc_prod/update_bus_info.timestamp
     if timestamp > 8 days then alert
+
+# Download data updated every day
+check file build_download_data with path /var/log/tfc_prod/build_download_data.timestamp
+    if timestamp > 26 hours then alert


### PR DESCRIPTION
Add a cronjob to run the download API's build_download_data command
every day, and monit configuration to check it's happened.

To deploy:

**Note** Needs https://github.com/SmartCambridge/tfc_web/pull/345/commits/9f189f53807ed46d33d952d6d58498b668d3fc5d from https://github.com/SmartCambridge/tfc_web/pull/345 deployed first.

1. As tfc_prod, run `crontab -e` and add the new 'Download data' job from `cronjobs/tfc_web_cronjobs.txt`

2. As root, copy `monit/conf-available/tfc_web_cronjobs` to `/etc/monit/conf-available/`; check with `monit -t`, deploy with `monit reload`